### PR TITLE
Fixed incorrect highlighting of 'type'

### DIFF
--- a/grammars/standard ml.cson
+++ b/grammars/standard ml.cson
@@ -113,7 +113,7 @@
     'name': 'constant.language.ml'
   }
   {
-    'begin': '\\s*(type|eqtype) .* ='
+    'begin': '\\b(type|eqtype) .* ='
     'captures':
       '1':
         'name': 'keyword.other.typeabbrev.ml'


### PR DESCRIPTION
The current code incorrectly highlights ‘type’ in

```
Hol_datatype `sample = Foo | Bar`;
```

which is erroneous.

An example of this in the wild is
https://github.com/HOL-Theorem-Prover/HOL/blob/master/examples/machine-code/instruction-set-models/x86_64/x64_coretypesScript.sml
