### PR TITLE
fixing eqtype highlighting

### DIFF
--- a/grammars/standard ml.cson
+++ b/grammars/standard ml.cson
@@ -158,7 +158,7 @@
             'name': 'keyword.other.ml'
           '2':
             'name': 'entity.name.type.abbrev.ml'
-        'match': '\\b(exception|type)\\s+([a-zA-Z][a-zA-Z0-9\'_]*)'
+        'match': '\\b(exception|type|eqtype)\\s+([a-zA-Z][a-zA-Z0-9\'_]*)'
         'name': 'meta.spec.ml.type'
       }
       {


### PR DESCRIPTION
I'm new to Atom so I'm not sure how to test this change, but right now `eqtype` does not highlight correctly and this PR should fix it. Here's what's currently wrong:

![screen shot 2016-02-11 at 8 15 33 pm](https://cloud.githubusercontent.com/assets/188095/12997173/4a12196c-d0fc-11e5-8240-b12f92dd4bcc.png)
